### PR TITLE
Updated i18n module for data-i18n-* attribute support

### DIFF
--- a/modules/i18n/README.md
+++ b/modules/i18n/README.md
@@ -1,11 +1,74 @@
 ## About
 
-JavaScript module to replace `__MSG_*__` i18n locale string in HTML WebExtension pages, like option pages or browser action pages. Import the `i18n.mjs` module file and run its `localizeDocument()` function on page load:
+JavaScript module for string localization in HTML WebExtension pages, such as option pages or browser action pages. Import the `i18n` object from the `i18n.mjs` module file and execute its `updateDocument()` function on page load.
 
+## Usage
+
+Historically, escaped localization keys of the form `__MSG_*__` inserted in the document markup (or as attribute values in certain cases) have been used for localized string substitutions.  The downside of this approach is that the escaped keys may be momentarily displayed prior to substitution once the document has loaded.
+
+In order to prevent this, an alternative is suggested through the use of the `data-i18n-textContent` attribute in conjunction with `i18n.mjs`.  The value of this attribute corresponds to an escaped or unescaped localization key.
+
+The attribute-based substitution approach is generalized so that other element properties/attributes resulting in visible text (such as document title or textbox placholder) can be localized using `data-i18n-*` patterned attributes (`data-i18n-text`, `data-i18n-placeholder`).
+
+This version of the `i18n` module is backwards-compatible with the original approach.
+
+main.js
 ```javascript
-import * as i18n from "i18n.mjs"
+import { i18n } from "i18n.mjs"
 
 document.addEventListener('DOMContentLoaded', () => {
-  i18n.localizeDocument();
+  i18n.updateDocument();
 }, { once: true });
+```
+
+## Examples
+
+Sample English-language localization file:
+
+_locales/en/messages.json
+```json
+{
+  "extensionName": { "message": "My Extension" },
+  "goodDay" : { "message": "Have a good day!" },
+  "textPrompt": { "message": "Enter some text" }
+}
+```
+
+Using the `data-i18n-*` attribute approach:
+
+main.html 
+```html
+<html>
+<head>
+  <title data-i18n-text="extensionName"></title>
+</head>
+<body>
+
+  <!-- using unescaped keys -->
+  <div data-i18n-textContent="goodDay"></div>
+  <input type="text" data-i18n-placeholder="textPrompt" />
+
+  <!-- using escaped keys -->
+  <div data-i18n-textContent="__MSG_goodDay__"></div>
+  <input type="text" data-i18n-placeholder="__MSG_textPrompt__" />
+
+</body>
+</html>
+```
+
+Using the legacy approach:
+
+main.html 
+```html
+<html>
+<head>
+  <title>__MSG_extensionName__</title>
+</head>
+<body>
+
+  <div>__MSG_goodDay__</div>
+  <input placeholder="__MSG_textPrompt__" />
+
+</body>
+</html>
 ```

--- a/modules/i18n/i18n.mjs
+++ b/modules/i18n/i18n.mjs
@@ -1,8 +1,15 @@
 /*
+ * This file is provided by the webext-support repository at
+ * https://github.com/thunderbird/webext-support
+ *
+ * For usage descriptions, please check:
+ * https://github.com/thunderbird/webext-support/tree/master/modules/i18n
+ *
+ * Version 2.0
+ *
  * Derived from:
  *
  * http://github.com/piroor/webextensions-lib-l10n
- * https://github.com/thunderbird/webext-support/blob/master/modules/i18n/i18n.mjs
  *
  * Original license:
  * The MIT License, Copyright (c) 2016-2019 YUKI "Piro" Hiroshi

--- a/modules/i18n/i18n.mjs
+++ b/modules/i18n/i18n.mjs
@@ -1,59 +1,158 @@
 /*
- * This file is provided by the webext-support repository at
- * https://github.com/thunderbird/webext-support
- *
- * For usage descriptions, please check:
- * https://github.com/thunderbird/webext-support/tree/master/modules/i18n
- *
- * Version 1.2
- *
  * Derived from:
+ *
  * http://github.com/piroor/webextensions-lib-l10n
+ * https://github.com/thunderbird/webext-support/blob/master/modules/i18n/i18n.mjs
  *
  * Original license:
  * The MIT License, Copyright (c) 2016-2019 YUKI "Piro" Hiroshi
  *
+ * Usage:
+ * 
+ * Call updateDocument() to perform localization insertions/replacements in the extension root document.
+ * updateAnyDocument(sourceDocument) performs the same operations against any arbitrary HTML document.
+ * 
+ * For a localization entry with the key "someItem" and an escaped key of __MSG_someItem__:
+ * 
+ * 1) Use the "data-i18n-textContent" attribute of an element to set the text, such as:
+ *      <div data-i18n-textContent="someItem"></div>                OR
+ *      <div data-i18n-textContent="__MSG_someItem__"></div>
+ * 
+ *      To set other properties or attributes of elements, use the form data-i18n-*, such as:
+ *          <title data-i18n-text="someItem"></title>                   // Assigns the document title text
+ *          <input type="text" data-i18n-placeholder="someItem" />      // Assigns the placeholder text for a textbox
+ *      
+ * 2) Use the legacy approach of directly applying escaped keys in the markup content, such as:
+ *      <div>__MSG_someItem__</div>
+ *      <div> 1) __MSG_someItem__: __MSG_someItemDesc__ </div>
+ * 
+ * 3) Use the legacy approach for element properties/attributes, such as:
+ *      <img alt="__MSG_someItem__"></img>
+ *  
  */
 
-const keyPrefix = "__MSG_";
+export const i18n = ((document, messenger) => {
 
-function updateString(string) {
-  let re = new RegExp(keyPrefix + "(.+?)__", "g");
-  return string.replace(re, (matched) => {
-    const key = matched.slice(keyPrefix.length, -2);
-    let rv = messenger.i18n.getMessage(key);
-    return rv || matched;
-  });
-};
+    // Private members
+    const i18nAttrRegex = /^data-i18n-(?<target>.*)/;
 
-function updateSubtree(node) {
-  const texts = document.evaluate(
-    'descendant::text()[contains(self::text(), "' + keyPrefix + '")]',
-    node,
-    null,
-    XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
-    null
-  );
-  for (let i = 0, maxi = texts.snapshotLength; i < maxi; i++) {
-    const text = texts.snapshotItem(i);
-    if (text.nodeValue.includes(keyPrefix))
-      text.nodeValue = updateString(text.nodeValue);
-  }
+    const propertyMapping = new Map([
+        ["textcontent", "textContent"]
+    ]);
 
-  const attributes = document.evaluate(
-    'descendant::*/attribute::*[contains(., "' + keyPrefix + '")]',
-    node,
-    null,
-    XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
-    null
-  );
-  for (let i = 0, maxi = attributes.snapshotLength; i < maxi; i++) {
-    const attribute = attributes.snapshotItem(i);
-    if (attribute.value.includes(keyPrefix))
-      attribute.value = updateString(attribute.value);
-  }
-};
+    let _extension = null;
+    let _keyPrefix = "__MSG_";
 
-export function localizeDocument() {
-  updateSubtree(document);
-};
+    const getTranslation = (placeholder) => {
+        const prefixRegex = new RegExp(_keyPrefix + "(.+?)__", "g");
+
+        return placeholder.replace(prefixRegex, (escapedKey) => {
+            const key = escapedKey.slice(_keyPrefix.length, -2);
+
+            const result = _extension
+                ? _extension.localeData.localizeMessage(key)
+                : messenger.i18n.getMessage(key);
+
+            return result || escapedKey;
+        });
+    };
+
+    const updateSubtreeSet = (sourceDocument, node, selector, update) => {
+        const items = sourceDocument.evaluate(
+            `descendant::${selector}`,
+            node,
+            null,
+            XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+            null
+        );
+
+        for (let i = 0, count = items.snapshotLength; i < count; i++) {
+            update(items.snapshotItem(i));
+        }
+    };
+
+    const updateSubtree = (sourceDocument, node) => {
+        // Update element properties (including textContent) or attributes based on data-i18n-* attributes assigned to the element
+        updateSubtreeSet(sourceDocument, node,
+            '*/@*[starts-with(name(), "data-i18n-")]',
+            (attr) => {
+                const key = attr.value;
+
+                let value;
+
+                // If using traditional i18n key placeholders of the form __MSG_*__...
+                if(key.includes(_keyPrefix)) {
+                    value = getTranslation(key);
+                }
+                // If using the direct i18n keys...
+                else {
+                    value = _extension
+                        ? _extension.localeData.localizeMessage(key)
+                        : messenger.i18n.getMessage(key);
+
+                        if(!value) {
+                            value = `** i18n error: ${key} **`;
+                            console.warn(`Missing i18n entry for key "${key}".`);
+                        }
+                }
+
+                const { ownerElement } = attr;
+                let { target } = i18nAttrRegex.exec(attr.name).groups;
+
+                if (propertyMapping.has(target)) {
+                    target = propertyMapping.get(target);
+                }
+
+                // If the target member is a property...
+                if (typeof ownerElement[target] !== undefined) {
+                    ownerElement[target] = value;
+                }
+                // Otherwise, assume it is an attribute
+                else {
+                    ownerElement.setAttribute(target, value);
+                }
+            }
+        );
+
+        // Update text nodes containing __MSG_*__ placeholders
+        updateSubtreeSet(sourceDocument, node,
+            `text()[contains(self::text(), "${_keyPrefix}")]`,
+            (text) => {
+                if (text.nodeValue.includes(_keyPrefix))
+                    text.nodeValue = getTranslation(text.nodeValue);
+            }
+        );
+
+        // Update element attributes (excluding data-i18n-*) containing __MSG_*__ placeholders
+        updateSubtreeSet(sourceDocument, node,
+            `*/@*[not(starts-with(name(), "data-i18n-"))][contains(., "${_keyPrefix}")]`,
+             (attr) => {
+                if (attr.value.includes(_keyPrefix))
+                    attr.value = getTranslation(attr.value);
+            }
+        );
+    };
+
+    // Public members
+    const updateAnyDocument = (sourceDocument, options = {}) => {
+        if (options) {
+            if (options.extension)
+                _extension = options.extension;
+            if (options.keyPrefix)
+                _keyPrefix = options.keyPrefix;
+        }
+
+        updateSubtree(sourceDocument, sourceDocument);
+    };
+
+    const updateDocument = (options = {}) => {
+        updateAnyDocument(document, options);
+    };
+
+
+    return {
+        updateAnyDocument: updateAnyDocument,
+        updateDocument: updateDocument
+    };
+
+})(document, messenger);


### PR DESCRIPTION
This implementation exports an object (i18n) rather than the single function localizeDocument.

Please see the updated README doc describing its use.